### PR TITLE
fix API regression with Excel12f

### DIFF
--- a/source/xlld/framework.d
+++ b/source/xlld/framework.d
@@ -103,7 +103,7 @@ unittest {
    Comments:
 */
 
-int Excel12f(int xlfn, LPXLOPER12 pxResult, LPXLOPER12[] args) nothrow @nogc
+int Excel12f(int xlfn, LPXLOPER12 pxResult, LPXLOPER12[] args...) nothrow @nogc
 {
     import xlld.xlcallcpp: Excel12v;
     import std.algorithm: all;
@@ -112,18 +112,19 @@ int Excel12f(int xlfn, LPXLOPER12 pxResult, LPXLOPER12[] args) nothrow @nogc
     return Excel12v(xlfn, pxResult, cast(int)args.length, cast(LPXLOPER12*)args.ptr);
 }
 
-int Excel12f(int xlfn, LPXLOPER12 pxResult, LPXLOPER12[] args...) nothrow @nogc {
-    return Excel12f(xlfn, pxResult, args);
-}
-
 int Excel12f(int xlfn, LPXLOPER12 result, XLOPER12[] args...) nothrow {
 
-    LPXLOPER12[] ptrArgs;
+    auto ptrArgs = new LPXLOPER12[args.length];
 
-    foreach(ref arg; args)
-        ptrArgs ~= () @trusted { return &arg; }();
+    foreach(i, ref arg; args)
+        ptrArgs[i] = () @trusted { return &arg; }();
 
     return Excel12f(xlfn, result, ptrArgs);
+}
+
+int Excel12f(int xlfn, LPXLOPER12 pxResult) nothrow @nogc
+{
+    return Excel12f(xlfn, pxResult, LPXLOPER12[].init);
 }
 
 __gshared immutable excel12Exception = new Exception("Error calling Excel12f");

--- a/source/xlld/xll.d
+++ b/source/xlld/xll.d
@@ -118,8 +118,7 @@ private void registerAllWorkSheetFunctions() {
 
     // get name of this XLL, needed to pass to xlfRegister
     static XLOPER12 dllName;
-    LPXLOPER12[] empty;
-    Excel12f(xlGetName, &dllName, empty);
+    Excel12f(xlGetName, &dllName);
 
     foreach(strings; getWorksheetFunctions.map!(a => a.toStringArray)) {
         auto opers = strings.map!(a => a.toXlOper(allocator)).array;


### PR DESCRIPTION
```
 Error: xlld.framework.Excel12f called with argument types (int, XLOPER12*) matches both:
..\AppData\Roaming\dub\packages\excel-d-0.2.12\excel-d\source\xlld\framework.d(115,5):     xlld.framework.Excel12f(int xlfn, XLOPER12* pxResult, XLOPER12*[] args...)
and:
..\AppData\Roaming\dub\packages\excel-d-0.2.12\excel-d\source\xlld\framework.d(119,5):     xlld.framework.Excel12f(int xlfn, XLOPER12* result, XLOPER12[] args...)
```