### PR TITLE
Fix aliasing issue in struct WorksheetFunction

### DIFF
--- a/source/xlld/wrap/worksheet.d
+++ b/source/xlld/wrap/worksheet.d
@@ -57,6 +57,8 @@ struct WorksheetFunction {
                 shortcutText.value, helpTopic.value, functionHelp.value
             ] ~ argumentHelp.value;
     }
+
+    const bool opEquals(const WorksheetFunction rhs) @safe pure { return optional == rhs.optional; }
 }
 
 // helper template to type-check variadic template constructor below


### PR DESCRIPTION
Currently this is blocking [1]. For a bit of background: up until now, dmd would use the aliased this object opEquals if the containing struct did not define an opEquals; in your case, the WorksheetFunction object was always compared through the Optional opEquals (which in this case is compiler generated). I'm not very familiar with this codebase so I don't know it is correct or not that way, but in order to maintain the current functionality and to also get rid of the blockage, I implemented the opEquals to spell out what is happening behind the scenes.

[1] https://github.com/dlang/dmd/pull/9289