### PR TITLE
remove overly strict @safe

### DIFF
--- a/source/xlld/conv/from.d
+++ b/source/xlld/conv/from.d
@@ -408,7 +408,6 @@ T fromXlOper(T, A)(XLOPER12* oper, ref A allocator) if(is(T == enum)) {
 
 // convert a user-defined struct
 T fromXlOper(T, A)(XLOPER12* oper, ref A allocator)
-    @safe
     if(isRegularStruct!T)
 {
     import xlld.conv.misc: stripMemoryBitmask;


### PR DESCRIPTION
why should it be forced?